### PR TITLE
Add unit tests for Survey & TextQ entities - Sprint 2

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/test/java/ca/syst4806proj/SurveyTextQPersistenceTest.java
+++ b/src/test/java/ca/syst4806proj/SurveyTextQPersistenceTest.java
@@ -1,0 +1,76 @@
+package ca.syst4806proj;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class SurveyTextQPersistenceTest {
+
+    @Autowired private TestEntityManager em;
+    @Autowired private UserRepository userRepository;
+    @Autowired private SurveyRepository surveyRepository;
+    @Autowired private TextQRepository textQRepository;
+
+    @Test
+    void savingSurveyCascadesAndOrdersTextQByOrdinalIndex() {
+        User owner = userRepository.save(new User("Owner 1"));
+
+        Survey s = new Survey();
+        s.setTitle("Survey Cascade Test");
+        s.setOwner(owner);
+
+        TextQ q1 = new TextQ(); q1.setPrompt("Q1"); q1.setOrdinalIndex(2);
+        TextQ q2 = new TextQ(); q2.setPrompt("Q2"); q2.setOrdinalIndex(1);
+        TextQ q3 = new TextQ(); q3.setPrompt("Q3"); q3.setOrdinalIndex(null);
+
+        s.addTextQ(q1);
+        s.addTextQ(q2);
+        s.addTextQ(q3);
+
+        surveyRepository.save(s);
+        em.flush();
+        em.clear();
+
+        Survey reloaded = surveyRepository.findById(s.getId()).orElseThrow();
+        List<TextQ> qs = reloaded.getTextQuestions();
+
+        assertThat(qs).hasSize(3);
+        assertThat(qs.get(0).getOrdinalIndex()).isEqualTo(1);
+        assertThat(qs.get(1).getOrdinalIndex()).isEqualTo(2);
+        assertThat(qs.get(2).getOrdinalIndex()).isNull();
+        assertThat(textQRepository.count()).isEqualTo(3);
+    }
+
+    @Test
+    void orphanRemovalDeletesTextQWhenRemovedFromSurvey() {
+        User owner = userRepository.save(new User("Owner 2"));
+
+        Survey s = new Survey();
+        s.setTitle("Orphan Removal Test");
+        s.setOwner(owner);
+
+        TextQ q = new TextQ(); q.setPrompt("Will be removed");
+        s.addTextQ(q);
+
+        surveyRepository.save(s);
+        em.flush();
+        em.clear();
+
+        Long qId = textQRepository.findAll().iterator().next().getId();
+        assertThat(textQRepository.findById(qId)).isPresent();
+
+        Survey loaded = surveyRepository.findById(s.getId()).orElseThrow();
+        TextQ toRemove = loaded.getTextQuestions().get(0);
+        loaded.removeTextQ(toRemove);
+        surveyRepository.save(loaded);
+
+        em.flush();
+        em.clear();
+
+        assertThat(textQRepository.findById(qId)).isNotPresent();
+    }
+}

--- a/src/test/java/ca/syst4806proj/SurveyUnitTest.java
+++ b/src/test/java/ca/syst4806proj/SurveyUnitTest.java
@@ -1,0 +1,41 @@
+package ca.syst4806proj;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SurveyUnitTest {
+
+    private Survey survey;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        survey = new Survey();
+        user = new User("TestUser");
+        survey.setTitle("Feedback Form");
+        survey.setOwner(user);
+    }
+
+    @Test
+    void testSurveyProperties() {
+        assertThat(survey.getTitle()).isEqualTo("Feedback Form");
+        assertThat(survey.getOwner()).isEqualTo(user);
+        assertThat(survey.getOwnerId()).isNull(); // because user not persisted
+    }
+
+    @Test
+    void testAddAndRemoveTextQ() {
+        TextQ q1 = new TextQ();
+        q1.setPrompt("Question 1?");
+        q1.setOrdinalIndex(1);
+
+        survey.addTextQ(q1);
+        assertThat(survey.getTextQuestions()).contains(q1);
+        assertThat(q1.getSurvey()).isEqualTo(survey);
+
+        survey.removeTextQ(q1);
+        assertThat(survey.getTextQuestions()).doesNotContain(q1);
+        assertThat(q1.getSurvey()).isNull();
+    }
+}

--- a/src/test/java/ca/syst4806proj/TextQUnitTest.java
+++ b/src/test/java/ca/syst4806proj/TextQUnitTest.java
@@ -1,0 +1,31 @@
+package ca.syst4806proj;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TextQUnitTest {
+
+    private TextQ textQ;
+
+    @BeforeEach
+    void setUp() {
+        textQ = new TextQ();
+        textQ.setPrompt("How are you?");
+        textQ.setOrdinalIndex(5);
+    }
+
+    @Test
+    void testBasicProperties() {
+        assertThat(textQ.getPrompt()).isEqualTo("How are you?");
+        assertThat(textQ.getOrdinalIndex()).isEqualTo(5);
+    }
+
+    @Test
+    void testSurveyBinding() {
+        Survey survey = new Survey();
+        textQ.setSurvey(survey);
+        assertThat(textQ.getSurvey()).isEqualTo(survey);
+        assertThat(textQ.getSurveyId()).isNull(); // not persisted, so id null
+    }
+}


### PR DESCRIPTION
### Summary
Added comprehensive unit and persistence tests for the Survey and TextQ entities.

### Details
- **SurveyUnitTest.java**: Validates Survey properties, add/remove TextQ methods, and owner binding.  
- **TextQUnitTest.java**: Tests prompt, ordinal index, and survey linkage behavior.  
- **SurveyTextQPersistenceTest.java**:  
  - Confirms cascade persistence from Survey → TextQ  
  - Verifies `@OrderBy(ordinalIndex ASC NULLS LAST)` ordering  
  - Tests `orphanRemoval = true` cleanup behavior

### Outcome
All tests passing locally in IntelliJ  
Builds successfully on GitHub Actions  
Ready for code review / TA verification

### Linked Project Task
**Sprint 2:** “Unit Tests for the newly created entities”
